### PR TITLE
Adding go-chglog to the Docker image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
 # Install Go tools
 RUN go install github.com/go-task/task/v3/cmd/task@v3.34.1 && \
     go install github.com/caarlos0/svu@v1.9.0 && \
+    go install github.com/git-chglog/git-chglog/cmd/git-chglog@latest && \
     go install github.com/goreleaser/goreleaser@v1.22.1 && \
     go install golang.org/x/tools/cmd/goimports@v0.17.0 && \
     curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2 && \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,8 +19,7 @@ repos:
       - id: go-imports
       - id: golangci-lint
         args: [--timeout=5m]
-      # TODO: Uncomment this when we have tests
-      # - id: go-unit-tests
+      - id: go-unit-tests
       - id: go-mod-tidy
 
   - repo: local

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -96,7 +96,6 @@ tasks:
     cmds:
       - pre-commit clean
       - git config --global --add safe.directory /workspace
-      - git rev-parse --is-inside-work-tree
       - pre-commit install
 
   pre-commit-run:
@@ -109,8 +108,3 @@ tasks:
     desc: Update pre-commit hooks to latest versions
     cmds:
       - pre-commit autoupdate
-
-  setup-dev:
-    desc: Set up development environment
-    cmds:
-      - task pre-commit-run


### PR DESCRIPTION
go-chglog needs to exist in the image for generating changelogs via the release workflow. Fixed/enabled unit tests in the pre-commit config and removed a debugging line in Taskfile.yml