### PR TITLE
Tell go vet to not care about vcs

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,7 +37,7 @@ tasks:
   lint:
     desc: Run linters
     cmds:
-      - go vet ./...
+      - go vet -buildvcs=false ./...
       - golangci-lint run
 
   clean:


### PR DESCRIPTION
I think `go vet` is causing the current failure in the pre-release workflow.