### PR TITLE
Fixing this disablevcs thing

### DIFF
--- a/.devcontainer/CI/devcontainer.json
+++ b/.devcontainer/CI/devcontainer.json
@@ -12,7 +12,7 @@
             ],
             "settings": {
                 "go.toolsEnvVars": {
-                    "GOFLAGS": "-mod=mod, -buildvcs=false",
+                    "GOFLAGS": "-mod=mod",
                     "GO111MODULE": "on"
                 },
                 "go.useLanguageServer": true,

--- a/.devcontainer/LOCAL/devcontainer.json
+++ b/.devcontainer/LOCAL/devcontainer.json
@@ -16,7 +16,7 @@
             ],
             "settings": {
                 "go.toolsEnvVars": {
-                    "GOFLAGS": "-mod=mod, -buildvcs=false",
+                    "GOFLAGS": "-mod=mod",
                     "GO111MODULE": "on"
                 },
                 "go.useLanguageServer": true,

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,6 +1,7 @@
 version: '3'
 
 vars:
+  GOFLAGS: "-buildvcs=false"
   BINARY_NAME: terraform-provider-docs-local
   GO_VERSION: '1.24'
   ARTIFACTS_DIR: artifacts
@@ -16,28 +17,33 @@ tasks:
     deps: [clean]
     cmds:
       - mkdir -p {{.ARTIFACTS_DIR}}
-      - go build -buildvcs=false -o {{.ARTIFACTS_DIR}}/{{.BINARY_NAME}} main.go
+      - go build {{.GOFLAGS}} -o {{.ARTIFACTS_DIR}}/{{.BINARY_NAME}} main.go
 
   build-all:
     desc: Build for multiple architectures
     deps: [clean]
     cmds:
       - mkdir -p {{.ARTIFACTS_DIR}}
-      - GOOS=darwin GOARCH=amd64 go build -buildvcs=false -o {{.ARTIFACTS_DIR}}/{{.BINARY_NAME}}-darwin-amd64 main.go
-      - GOOS=darwin GOARCH=arm64 go build -buildvcs=false -o {{.ARTIFACTS_DIR}}/{{.BINARY_NAME}}-darwin-arm64 main.go
-      - GOOS=linux GOARCH=amd64 go build -buildvcs=false -o {{.ARTIFACTS_DIR}}/{{.BINARY_NAME}}-linux-amd64 main.go
-      - GOOS=linux GOARCH=arm64 go build -buildvcs=false -o {{.ARTIFACTS_DIR}}/{{.BINARY_NAME}}-linux-arm64 main.go
-      - GOOS=windows GOARCH=amd64 go build -buildvcs=false -o {{.ARTIFACTS_DIR}}/{{.BINARY_NAME}}-windows-amd64.exe main.go
+      - GOOS=darwin GOARCH=amd64 go build {{.GOFLAGS}} -o {{.ARTIFACTS_DIR}}/{{.BINARY_NAME}}-darwin-amd64 main.go
+      - GOOS=darwin GOARCH=arm64 go build {{.GOFLAGS}} -o {{.ARTIFACTS_DIR}}/{{.BINARY_NAME}}-darwin-arm64 main.go
+      - GOOS=linux GOARCH=amd64 go build {{.GOFLAGS}} -o {{.ARTIFACTS_DIR}}/{{.BINARY_NAME}}-linux-amd64 main.go
+      - GOOS=linux GOARCH=arm64 go build {{.GOFLAGS}} -o {{.ARTIFACTS_DIR}}/{{.BINARY_NAME}}-linux-arm64 main.go
+      - GOOS=windows GOARCH=amd64 go build {{.GOFLAGS}} -o {{.ARTIFACTS_DIR}}/{{.BINARY_NAME}}-windows-amd64.exe main.go
 
   test:
     desc: Run tests
     cmds:
-      - go test ./...
+      - go test {{.GOFLAGS}} ./...
 
   lint:
     desc: Run linters
     cmds:
-      - go vet -buildvcs=false ./...
+      # Add the workspace directory to the safe directories list
+      # to avoid issues with git in CI/CD environments
+      # This is necessary for tools like golangci-lint that use git
+      # to check for modified files
+      - git config --global --add safe.directory /workspace
+      - go vet {{.GOFLAGS}} ./...
       - golangci-lint run
 
   clean:


### PR DESCRIPTION
I think since the pre-release workflow doesn't run pre-commit that the /workspace directory is never added as a git safe directory. I believe that this is causing golang-ci lint to fail. I also fixed/removed misconfigured GOFLAGS for both devcontainer configurations and moved the GOFLAGS into the Taskfile as a variable that is just passed to the go-related tasks.