### PR TITLE
Fix NEXT_TAG and CURRENT_TAG and Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.24-bullseye
 
 # Install basic development tools
-RUN apt-get update && apt-get install -y \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -yqq \
     git \
     curl \
     jq \
@@ -16,7 +16,7 @@ RUN go install github.com/go-task/task/v3/cmd/task@v3.42.1 && \
     go install github.com/goreleaser/goreleaser/v2@v2.8.2 && \
     go install golang.org/x/tools/cmd/goimports@v0.31.0 && \
     curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.0.2 && \
-    pip install pre-commit
+    pip install -q pre-commit
 
 # Add Go binaries to PATH
 ENV PATH="${PATH}:$(go env GOPATH)/bin"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -62,8 +62,8 @@ tasks:
       VERSION_TYPE: patch
     deps: [lint, build, test]
     cmds:
-      - CURRENT_TAG=$(svu current)
-      - NEXT_TAG=$(svu {{.VERSION_TYPE}})
+      - CURRENT_TAG=$(sh "svu current")
+      - NEXT_TAG=$(sh "svu {{.VERSION_TYPE}}")
       - echo "Bumping version from $CURRENT_TAG to $NEXT_TAG"
       - task changelog -- NEXT_TAG=$NEXT_TAG
       - git add CHANGELOG.md


### PR DESCRIPTION
Making some of the installation things more silent in the Dockerfile so the build/workflow logs are less verbose. Fixing an issue where NEXT_TAG and CURRENT_TAG were not being properly set in the pre-release workflow.