### PR TITLE
Use the right syntax for Taskfile variable refs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,21 +1,22 @@
 FROM golang:1.24-bullseye
 
 # Install basic development tools
-RUN DEBIAN_FRONTEND=noninteractive apt-get update -yqq && apt-get install -yqq \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -yqq > /dev/null && \
+    apt-get install -yqq \
     git \
     curl \
     jq \
     wget \
-    python3-pip \
+    python3-pip > /dev/null \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Go tools
-RUN go install github.com/go-task/task/v3/cmd/task@v3.42.1 && \
-    go install github.com/caarlos0/svu/v3@v3.2.3 && \
-    go install github.com/git-chglog/git-chglog/cmd/git-chglog@latest && \
-    go install github.com/goreleaser/goreleaser/v2@v2.8.2 && \
-    go install golang.org/x/tools/cmd/goimports@v0.31.0 && \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.0.2 && \
+RUN go install github.com/go-task/task/v3/cmd/task@v3.42.1 > /dev/null && \
+    go install github.com/caarlos0/svu/v3@v3.2.3 > /dev/null && \
+    go install github.com/git-chglog/git-chglog/cmd/git-chglog@latest > /dev/null && \
+    go install github.com/goreleaser/goreleaser/v2@v2.8.2 > /dev/null && \
+    go install golang.org/x/tools/cmd/goimports@v0.31.0 > /dev/null && \
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.0.2 > /dev/null && \
     pip install -q pre-commit
 
 # Add Go binaries to PATH

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -59,14 +59,14 @@ tasks:
   get-current-tag:
     desc: Get the current version tag
     cmds:
-      - sh -c "svu current"
+      - svu current
 
   get-next-tag:
     desc: Get the next version tag based on VERSION_TYPE
     vars:
       VERSION_TYPE: patch
     cmds:
-      - sh -c "svu {{.VERSION_TYPE}}"
+      - svu {{.VERSION_TYPE}}
 
   bump-version:
     desc: Bump version (patch, minor, or major)
@@ -76,33 +76,33 @@ tasks:
     cmds:
       - CURRENT_TAG=$(task get-current-tag)
       - NEXT_TAG=$(task get-next-tag VERSION_TYPE={{.VERSION_TYPE}})
-      - echo "Bumping version from $CURRENT_TAG to $NEXT_TAG"
-      - task changelog -- NEXT_TAG=$NEXT_TAG
+      - echo "Bumping version from {{.CURRENT_TAG}} to {{.NEXT_TAG}}"
+      - task changelog -- NEXT_TAG={{.NEXT_TAG}}
       - git add CHANGELOG.md
-      - git commit -am "Release $NEXT_TAG"
-      - git tag -a $NEXT_TAG -m "Release $NEXT_TAG"
-      - git push origin $NEXT_TAG
+      - git commit -am "Release {{.NEXT_TAG}}"
+      - git tag -a {{.NEXT_TAG}} -m "Release {{.NEXT_TAG}}"
+      - git push origin {{.NEXT_TAG}}
 
   bump-patch:
     desc: Bump patch version
     vars:
       VERSION_TYPE: patch
     cmds:
-      - task bump-version
+      - task bump-version VERSION_TYPE={{.VERSION_TYPE}}
 
   bump-minor:
     desc: Bump minor version
     vars:
       VERSION_TYPE: minor
     cmds:
-      - task bump-version
+      - task bump-version VERSION_TYPE={{.VERSION_TYPE}}
 
   bump-major:
     desc: Bump major version
     vars:
       VERSION_TYPE: major
     cmds:
-      - task bump-version
+      - task bump-version VERSION_TYPE={{.VERSION_TYPE}}
 
   changelog:
     desc: Generate changelog

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
-	github.com/go-git/gcfg/v2 v2.0.1 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,7 +24,6 @@ github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
-github.com/go-git/gcfg/v2 v2.0.1/go.mod h1:/lv2NsxvhepuMrldsFilrgct6pxzpGdSRC13ydTLSLs=
 github.com/go-git/go-billy/v5 v5.6.2 h1:6Q86EsPXMa7c3YZ3aLAQsMA0VlWmy43r6FHqa/UNbRM=
 github.com/go-git/go-billy/v5 v5.6.2/go.mod h1:rcFC2rAsp/erv7CMz9GczHcuD0D32fWzH+MJAU+jaUU=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=


### PR DESCRIPTION
I was trying to use `$NEXT_TAG` instead of `{{.NEXT_TAG}}` and similar in the Taskfile. More quieting of the Dockerfile for cleaner build logs.