### PR TITLE
Bot can push commits, now fix goreleaser error

### DIFF
--- a/.devcontainer/LOCAL/setup-local.sh
+++ b/.devcontainer/LOCAL/setup-local.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-# Clone my dotfiles repo and run the setup script to install all the things
-
-git clone https://github.com/jreslock/dotfiles.git $HOME/dotfiles
-$HOME/dotfiles/setup

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,12 +46,16 @@ release:
   github:
     owner: jreslock
     name: terraform-provider-docs-local
-  draft: false
+  draft: true
   prerelease: auto
   mode: replace
   header: |
     ## Changelog
+    {{- if .Changelog }}
     {{ .Changelog }}
+    {{- else }}
+    No changelog available for this release.
+    {{- end }}
 
 brews:
   - name: terraform-provider-docs-local


### PR DESCRIPTION
Just missing some changelog stuff in the goreleaser.yml file that is causing the very last error creating the release. Commit and tags push ok and are now able to bypass the ruleset using the token generated from the app. PROGRESS!