### PR TITLE
Just use the changelog we just generated

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,13 +49,9 @@ release:
   draft: true
   prerelease: auto
   mode: replace
-  header: |
-    ## Changelog
-    {{- if .Changelog }}
-    {{ .Changelog }}
-    {{- else }}
-    No changelog available for this release.
-    {{- end }}
+  header:
+    from_file:
+      path: ./CHANGELOG.md
 
 brews:
   - name: terraform-provider-docs-local


### PR DESCRIPTION
We don't need a separate changelog config in goreleaser we are already usig git-chlog to generate a changelog and we can just read that file when goreleaser creates the release instead of trying to make new stuff.