### PR TITLE
fix: Update devcontainer.json and providers.yaml

### DIFF
--- a/.devcontainer/CI/devcontainer.json
+++ b/.devcontainer/CI/devcontainer.json
@@ -7,7 +7,6 @@
         "vscode": {
             "extensions": [
                 "golang.go",
-                "eamodio.gitlens",
                 "ms-azuretools.vscode-docker"
             ],
             "settings": {

--- a/.devcontainer/LOCAL/devcontainer.json
+++ b/.devcontainer/LOCAL/devcontainer.json
@@ -6,6 +6,7 @@
     "customizations": {
         "vscode": {
             "extensions": [
+                "amazonwebservices.aws-toolkit-vscode@3.46.0",
                 "golang.go",
                 "github.copilot",
                 "github.vscode-pull-request-github",

--- a/providers.yaml
+++ b/providers.yaml
@@ -5,28 +5,35 @@ target_dir: /Users/jreslock/docs/terraform-providers
 providers:
   aws:
     repo: "hashicorp/terraform-provider-aws"
-    description: AWS provider for Terraform
+    description: AWS
   awscc:
     repo: "hashicorp/terraform-provider-awscc"
-    description: AWS Cloud Control provider for Terraform
+    description: AWS Cloud Control
   databricks:
     repo: "databricks/terraform-provider-databricks"
-    description: Databricks provider for Terraform
+    description: Databricks
   external:
     repo: "hashicorp/terraform-provider-external"
-    description: External provider for Terraform
+    description: External
+  google:
+    repo: "hashicorp/terraform-provider-google"
+    description: Google
   github:
     repo: "integrations/terraform-provider-github"
-    description: GitHub provider for Terraform
+    description: GitHub
   random:
     repo: "hashicorp/terraform-provider-random"
-    description: Random provider for Terraform
+    description: Random
   snowflake:
-    repo: "snowflake-labs/terraform-provider-snowflake"
-    description: Snowflake provider for Terraform
-  sumologic:
-    repo: "sumologic/terraform-provider-sumologic"
-    description: SumoLogic provider for Terraform
+    repo: "snowflakedb/terraform-provider-snowflake"
+    description: Snowflake
+  # SumoLogic is not supported yet due to their use of `master1` vs. `main`
+  # sumologic:
+  #   repo: "sumologic/terraform-provider-sumologic"
+  #   description: SumoLogic provider for Terraform
+  tls:
+    repo: "hashicorp/terraform-provider-tls"
+    description: TLS
   time:
     repo: "hashicorp/terraform-provider-time"
-    description: Time provider for Terraform
+    description: Time


### PR DESCRIPTION
Fixing the local devcontainer configuration to install the aws toolkit extension and keep it pinned to version 3.46.0 to preserve SSO profile authentication functionality that is broken in versions >3.46.0 (reference https://github.com/issues/created?issue=aws%7Caws-toolkit-vscode%7C6782)