### PR TITLE
fix: Branch detection remote, branch arg, tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,15 @@ go build
 
 ### Configuration
 
-Create a `providers.yaml` file with your desired providers. You can name the file anything you would like but the utility looks for a `providers.yaml` by default if you prefer less typing.
-
-Currently the tool requires that the source repositories all have a `main` branch. This is a bug/design flaw and will be addressed soon. Repositories with `master` instead of `main` do not clone properly and throw an error. Again, this is known and will be addressed in an upcoming release.
+Create a `providers.yaml` file with your desired providers. You can name the file anything you would like but the utility looks for a `providers.yaml` by default if you prefer less typing. You can optionally specify the desired branch to clone. The default behavior if no branch is specified will auto-detect the HEAD branch from the remote repository.
 
 ```yaml
-target_dir: terraform-providers  # Optional, defaults to "terraform-providers"
+target_dir: terraform-providers  # Optional, defaults to "./terraform-providers"
 providers:
   aws:
     repo: hashicorp/terraform-provider-aws
     description: AWS provider for Terraform
+    branch: main # Optional, if not set we auto-detect the HEAD branch from the remote
   azurerm:
     repo: hashicorp/terraform-provider-azurerm
     description: Azure provider for Terraform
@@ -64,6 +63,9 @@ terraform-provider-docs-local clone-all
 
 # Clone a specific provider
 terraform-provider-docs-local clone-one -p aws
+
+# Clone a specific provider at a desired branch
+terraform-provider-docs-local clone-one -p sumologic -b master
 
 # List available providers
 terraform-provider-docs-local list

--- a/providers.yaml
+++ b/providers.yaml
@@ -1,6 +1,7 @@
 # This file is used to configure the Terraform provider documentation
 # It specifies the target directory for cloned provider repositories
-# and the list of providers and their respective repository names
+# and the list of providers and their respective repository names,
+# optionally desired branch to clone, and a description.
 target_dir: /Users/jreslock/docs/terraform-providers
 providers:
   aws:
@@ -9,6 +10,9 @@ providers:
   awscc:
     repo: "hashicorp/terraform-provider-awscc"
     description: AWS Cloud Control
+  azure:
+    repo: "hashicorp/terraform-provider-azurerm"
+    description: Azure
   databricks:
     repo: "databricks/terraform-provider-databricks"
     description: Databricks
@@ -27,10 +31,10 @@ providers:
   snowflake:
     repo: "snowflakedb/terraform-provider-snowflake"
     description: Snowflake
-  # SumoLogic is not supported yet due to their use of `master1` vs. `main`
-  # sumologic:
-  #   repo: "sumologic/terraform-provider-sumologic"
-  #   description: SumoLogic provider for Terraform
+  sumologic:
+    repo: "sumologic/terraform-provider-sumologic"
+    description: SumoLogic
+    # branch: "master"
   tls:
     repo: "hashicorp/terraform-provider-tls"
     description: TLS


### PR DESCRIPTION
Extended the argument parsing to allow/accept a branch as well as adding to the example `providers.yaml`, updated tests and `README.md` to reflect these changes/additions. 

This should resolve #86 

Will make this a new release.