### PR TITLE
fix: Release workflow should handle single quotes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
             echo "bump=${{ github.event.inputs.bump }}" >> $GITHUB_OUTPUT
           else
             echo "Checking for bump label..."
-            LABELS=$(echo '${{ toJson(github.event.pull_request.labels) }}' | jq -r 'map(.name) | join(",")')
+            LABELS=$(echo '${{ toJson(github.event.pull_request.labels) }}' | jq -r 'map(.name | gsub("'"; "")) | join(",")')
 
             echo "Labels: $LABELS"
             BUMP_LABELS=$(echo "$LABELS" | grep -oE "bump:(major|minor|patch)" | sort | uniq)


### PR DESCRIPTION
Release workflow was choking on PR labels if the description contained a single quote such as "Something isn't right". This fixes the problem by naively globally substituting a space for single quotes if found in label text. This should work fine for the release context but in a more general sense is not the best way to fix the problem.