### PR TITLE
fix: Add clone-all command, update devcontainer

### DIFF
--- a/.devcontainer/CI/devcontainer.json
+++ b/.devcontainer/CI/devcontainer.json
@@ -21,7 +21,7 @@
                 ],
                 "editor.formatOnSave": true,
                 "editor.codeActionsOnSave": {
-                    "source.organizeImports": true
+                    "source.organizeImports": "always"
                 }
             }
         }

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,26 +1,39 @@
-FROM golang:1.24-bullseye
+# syntax=docker/dockerfile:1.7
+
+FROM public.ecr.aws/docker/library/golang:1.24.2-bookworm
+
+# Add binaries to PATH
+ENV PATH="/root/.local/bin:$(go env GOPATH)/bin:${PATH}"
 
 # Install basic development tools
-RUN DEBIAN_FRONTEND=noninteractive apt-get update -yqq > /dev/null && \
+RUN DEBIAN_FRONTEND=noninteractive apt update -yqq && apt install ca-certificates -yqq && \
+    echo 'deb [trusted=yes] https://apt.fury.io/caarlos0/ /' | tee /etc/apt/sources.list.d/caarlos0.list && \
+    echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list && \
+    DEBIAN_FRONTEND=noninteractive apt update -yqq > /dev/null && \
     apt-get install -yqq \
-    git \
     curl \
+    git \
+    goreleaser \
     jq \
-    wget \
-    python3-pip > /dev/null \
-    && rm -rf /var/lib/apt/lists/*
+    pipx \
+    svu \
+    unzip \
+    wget && \
+    rm -rf /var/lib/apt/lists/* && \
+    pipx install pre-commit && \
+    pipx install go-task-bin
 
 # Install Go tools
-RUN go install github.com/go-task/task/v3/cmd/task@v3.42.1 > /dev/null && \
-    go install github.com/caarlos0/svu/v3@v3.2.3 > /dev/null && \
-    go install github.com/git-chglog/git-chglog/cmd/git-chglog@latest > /dev/null && \
-    go install github.com/goreleaser/goreleaser/v2@v2.8.2 > /dev/null && \
+RUN ARCH=$(dpkg --print-architecture) && \
+    # git-chglog
+    curl -sSL -o git-chglog.tar.gz https://github.com/git-chglog/git-chglog/releases/download/v0.15.4/git-chglog_0.15.4_linux_${ARCH}.tar.gz && \
+    tar xzf git-chglog.tar.gz -C /usr/local/bin git-chglog && \
+    chmod +x /usr/local/bin/git-chglog && \
+    rm git-chglog.tar.gz && \
+    # goimports
     go install golang.org/x/tools/cmd/goimports@v0.31.0 > /dev/null && \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.0.2 > /dev/null && \
-    pip install -q pre-commit
-
-# Add Go binaries to PATH
-ENV PATH="${PATH}:$(go env GOPATH)/bin"
+    # golangci-lint
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.0.2 > /dev/null
 
 # Set working directory
 WORKDIR /workspace

--- a/.devcontainer/LOCAL/devcontainer.json
+++ b/.devcontainer/LOCAL/devcontainer.json
@@ -27,7 +27,7 @@
                 ],
                 "editor.formatOnSave": true,
                 "editor.codeActionsOnSave": {
-                    "source.organizeImports": true
+                    "source.organizeImports": "always"
                 },
                 "terminal.integrated.defaultProfile.linux": "zsh",
                 "terminal.integrated.profiles.linux": {


### PR DESCRIPTION
Adding the clone-all command back in because it was mistakenly removed while doing updates to use cobra for arg parsing. Updating the dev container to be a bit smaller, less reliance on `go install`.