### PR TITLE
(fix): Fixing some bugs in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,8 @@ jobs:
   release:
     if: >
       github.event.pull_request.merged == true &&
-      github.event.pull_request.base.ref == 'main' ||
+      github.event.pull_request.base.ref == 'main' &&
+      contains(github.event.pull_request.labels.*.name, 'bump:') ||
       github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
@@ -43,7 +44,12 @@ jobs:
             echo "bump=${{ github.event.inputs.bump }}" >> $GITHUB_OUTPUT
           else
             echo "Checking for bump label..."
-            LABELS=$(echo '${{ toJson(github.event.pull_request.labels) }}' | jq -r 'map(.name | gsub("'"; "")) | join(",")')
+            LABELS=$(echo '${{ toJson(github.event.pull_request.labels) }}' | jq -r 'if length > 0 then map(.name) | join(",") else "" end')
+
+            if [[ -z "$LABELS" ]]; then
+              echo "No labels found on the pull request. Skipping workflow."
+              exit 0
+            fi
 
             echo "Labels: $LABELS"
             BUMP_LABELS=$(echo "$LABELS" | grep -oE "bump:(major|minor|patch)" | sort | uniq)

--- a/.whitesource
+++ b/.whitesource
@@ -6,7 +6,7 @@
     "baseBranches": []
   },
   "scanSettingsSAST": {
-    "enableScan": false,
+    "enableScan": true,
     "scanPullRequests": false,
     "incrementalScan": true,
     "baseBranches": [],


### PR DESCRIPTION
The release workflow was not handling cases where a merged pr no labels. There is now logic to check for this in multiple places.